### PR TITLE
require vec3 directly

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,11 +5,9 @@ var abs = Math.abs;
 module.exports = init;
 
 var MAX_CPU_SPIN = 10;
-var vec3;
+var vec3=require('vec3');
 
-function init(mineflayer) {
-
-    vec3 = mineflayer.vec3;
+function init() {
 
     function inject(bot) {
 

--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
   "author": "Darthfett",
   "license": "BSD",
   "readmeFilename": "README.md",
-  "gitHead": "a2f8d6963512aa00d0dc4693badb74fa908976b4"
+  "gitHead": "a2f8d6963512aa00d0dc4693badb74fa908976b4",
+  "dependencies": {
+    "vec3": "^0.1.3"
+  }
 }


### PR DESCRIPTION
needed in mineflayer 2.0.0

could you release a new version after merging this ? (also if you want this repo could move to the PrismarineJs org)